### PR TITLE
fix: add data/grids dir creation to datasets Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ CSS=
 
 ## datasets: re-create snailz parameters and datasets
 datasets:
+	@mkdir -p data/grids
 	snailz params --outdir params
 	snailz everything --paramsdir params --datadir data
 


### PR DESCRIPTION
Just to avoid this error when running `make datasets` for the first time:

```
$ make datasets
snailz params --outdir params
snailz everything --paramsdir params --datadir data
Traceback (most recent call last):
  File "/opt/wp4ds/.venv/bin/snailz", line 8, in <module>
    sys.exit(clui.main())
             ^^^^^^^^^^^
  File "/opt/wp4ds/.venv/lib/python3.11/site-packages/snailz/clui.py", line 46, in main
    options.func(options)
  File "/opt/wp4ds/.venv/lib/python3.11/site-packages/snailz/clui.py", line 79, in everything
    grids_data_dir.mkdir(exist_ok=True)
  File "/opt/homebrew/anaconda3/lib/python3.11/pathlib.py", line 1116, in mkdir
    os.mkdir(self, mode)
FileNotFoundError: [Errno 2] No such file or directory: 'data/grids'
make: *** [datasets] Error 1
```