### PR TITLE
fix: Update page.html template with UTF-8 charset and copyright symbol

### DIFF
--- a/docs/01_intro/index.html
+++ b/docs/01_intro/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>Introduction</title>
+<meta charset="utf-8"/>
 <link href="../static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/02_http/index.html
+++ b/docs/02_http/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>HTTP</title>
+<meta charset="utf-8"/>
 <link href="../static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/03_json/index.html
+++ b/docs/03_json/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>Serving JSON</title>
+<meta charset="utf-8"/>
 <link href="../static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/04_db/index.html
+++ b/docs/04_db/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>Using a Database</title>
+<meta charset="utf-8"/>
 <link href="../static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/05_test/index.html
+++ b/docs/05_test/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>Testing the Server</title>
+<meta charset="utf-8"/>
 <link href="../static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/06_html/index.html
+++ b/docs/06_html/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>Serving HTML</title>
+<meta charset="utf-8"/>
 <link href="../static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/07_forms/index.html
+++ b/docs/07_forms/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>Using Forms</title>
+<meta charset="utf-8"/>
 <link href="../static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/08_js/index.html
+++ b/docs/08_js/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>An Hour of JavaScript</title>
+<meta charset="utf-8"/>
 <link href="../static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/09_browser/index.html
+++ b/docs/09_browser/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>JavaScript in the Browser</title>
+<meta charset="utf-8"/>
 <link href="../static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/10_htmx/index.html
+++ b/docs/10_htmx/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>Using HTMX</title>
+<meta charset="utf-8"/>
 <link href="../static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/11_perm/index.html
+++ b/docs/11_perm/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>Permissions</title>
+<meta charset="utf-8"/>
 <link href="../static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/12_migrate/index.html
+++ b/docs/12_migrate/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>Database Migration</title>
+<meta charset="utf-8"/>
 <link href="../static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/13_auth/index.html
+++ b/docs/13_auth/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>Authentication</title>
+<meta charset="utf-8"/>
 <link href="../static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/14_test/index.html
+++ b/docs/14_test/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>Testing Again</title>
+<meta charset="utf-8"/>
 <link href="../static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/15_access/index.html
+++ b/docs/15_access/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>Accessibility</title>
+<meta charset="utf-8"/>
 <link href="../static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/99_cert/index.html
+++ b/docs/99_cert/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>Certificates</title>
+<meta charset="utf-8"/>
 <link href="../static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/code_of_conduct.html
+++ b/docs/code_of_conduct.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>Code of Conduct</title>
+<meta charset="utf-8"/>
 <link href="./static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/contributing.html
+++ b/docs/contributing.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>Contributing</title>
+<meta charset="utf-8"/>
 <link href="./static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/data/assays.json
+++ b/docs/data/assays.json
@@ -225,7 +225,7 @@
         {
             "sample_id": 62,
             "kind": "JESS",
-            "start": "2023-11-08",
+            "start": "2023-11-09",
             "end": null
         },
         {
@@ -2053,7 +2053,7 @@
         {
             "plate_id": 202,
             "sample_id": 77,
-            "date": "2023-11-05",
+            "date": "2023-11-06",
             "filename": "fdf85f1a.csv"
         },
         {

--- a/docs/glossary.html
+++ b/docs/glossary.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>Glossary</title>
+<meta charset="utf-8"/>
 <link href="./static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>Web Programming for Data Scientists</title>
+<meta charset="utf-8"/>
 <link href="./static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/docs/license.html
+++ b/docs/license.html
@@ -3,6 +3,7 @@
 <html>
 <head>
 <title>License</title>
+<meta charset="utf-8"/>
 <link href="./static/page.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>

--- a/templates/page.html
+++ b/templates/page.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title></title>
+    <meta charset="UTF-8">
     {% if css_file %}<link rel="stylesheet" href="@root/static/{{css_file}}" type="text/css">{% endif %}
     <link rel="stylesheet" href="@root/static/page.css" type="text/css">
   </head>
@@ -10,7 +11,7 @@
 {{content}}
     </main>
     <footer>
-      Copyright © 2024 <a href="@root/contributing.html">the authors</a>
+      Copyright &copy; 2024 <a href="@root/contributing.html">the authors</a>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
Avoid bad encoding artifacts such as this one: `Copyright Â© 2024`