### PR TITLE
fix: Convert Polars DataFrame to JSON serializable format

### DIFF
--- a/03_json/server_err.py
+++ b/03_json/server_err.py
@@ -12,7 +12,7 @@ def make_server(data):
 
     @app.get("/")
     def root():
-        return app.data.write_json()
+        return app.data.to_dicts()
 
     @app.get("/col/{name}")
     def column(name: str):

--- a/03_json/server_func.py
+++ b/03_json/server_func.py
@@ -12,7 +12,8 @@ def make_server(data):
 
     @app.get("/")
     def root():
-        return app.data.write_json()
+        # Convert the Polars DataFrame to a list of dictionaries
+        return app.data.to_dicts()
 
     return app
 

--- a/03_json/server_routes.py
+++ b/03_json/server_routes.py
@@ -12,7 +12,7 @@ def make_server(data):
 
     @app.get("/")
     def root():
-        return app.data.write_json()
+        return app.data.to_dicts()
 
     @app.get("/col/{name}")
     def column(name: str):


### PR DESCRIPTION
This is what I think was happening: Polars returns a `DataFrame` that is stored in a `data` variable. Now, `data.write_json()` returns a simple string as a JSON representation of the DataFrame. FastAPI doesn't recognize it as a proper JSON object and returns this:

<img width="1465" alt="image" src="https://github.com/user-attachments/assets/729fa73d-e0d0-486c-8343-63ba94eb8d06">

We can properly hint FastAPI to recognize the Polars DataFrame as a JSON object by using the `to_dicts` method of the `polars.DataFrame`. This method converts the DataFrame to a list of dictionaries. FastAPI can automatically convert this list to a JSON response.

I have been playing with Polars to test my assumption:
```
>>> import polars as pl
>>> pl.read_csv('./data/staff.csv')
shape: (7, 3)
┌──────────┬──────────┬──────────┐
│ staff_id ┆ personal ┆ family   │
│ ---      ┆ ---      ┆ ---      │
│ i64      ┆ str      ┆ str      │
╞══════════╪══════════╪══════════╡
│ 1        ┆ Vello    ┆ Paal     │
│ 2        ┆ Viktoria ┆ Hallik   │
│ 3        ┆ Linda    ┆ Mõttus   │
│ 4        ┆ Sergey   ┆ Rätsep   │
│ 5        ┆ Anu      ┆ Valk     │
│ 6        ┆ Maria    ┆ Kelder   │
│ 7        ┆ Laura    ┆ Maksimov │
└──────────┴──────────┴──────────┘
>>> data = pl.read_csv('./data/staff.csv')
>>> data.write_json()
'[{"staff_id":1,"personal":"Vello","family":"Paal"},{"staff_id":2,"personal":"Viktoria","family":"Hallik"},{"staff_id":3,"personal":"Linda","family":"Mõttus"},{"staff_id":4,"personal":"Sergey","family":"Rätsep"},{"staff_id":5,"personal":"Anu","family":"Valk"},{"staff_id":6,"personal":"Maria","family":"Kelder"},{"staff_id":7,"personal":"Laura","family":"Maksimov"}]'
>>> print(type(data))
<class 'polars.dataframe.frame.DataFrame'>
>>> print(type(data.write_json()))
<class 'str'>
>>> print(type(data.to_dicts()))
<class 'list'>
>>> data.to_dicts()
[{'staff_id': 1, 'personal': 'Vello', 'family': 'Paal'}, {'staff_id': 2, 'personal': 'Viktoria', 'family': 'Hallik'}, {'staff_id': 3, 'personal': 'Linda', 'family': 'Mõttus'}, {'staff_id': 4, 'personal': 'Sergey', 'family': 'Rätsep'}, {'staff_id': 5, 'personal': 'Anu', 'family': 'Valk'}, {'staff_id': 6, 'personal': 'Maria', 'family': 'Kelder'}, {'staff_id': 7, 'personal': 'Laura', 'family': 'Maksimov'}]
```

Now it works correctly:
<img width="1282" alt="image" src="https://github.com/user-attachments/assets/4fa435cf-3dc2-442c-bf9f-650202d87a91">

And we can pretty-print it:
<img width="325" alt="image" src="https://github.com/user-attachments/assets/8ae32975-646a-40e2-b727-36ae31c69398">
