### PR TITLE
Fix row lookup endpoint to correctly handle staff_id existence check

### DIFF
--- a/03_json/server_err.py
+++ b/03_json/server_err.py
@@ -22,7 +22,7 @@ def make_server(data):
 
     @app.get("/row/{staff_id}")
     def row(staff_id: int):
-        if not (0 <= staff_id < len(app.data)):
+        if staff_id not in app.data["staff_id"]:
             raise HTTPException(status_code=404, detail=f"Row {staff_id} not found")
         return app.data.filter(pl.col("staff_id") == staff_id).row(0, named=True)
 


### PR DESCRIPTION
The current implementation has two issues:

1.  The `row/{staff_id}` endpoint will raise an error if the user types `row/0` (the `staff_id` in the CSV file starts from 1)
2.  The condition `0 <= staff_id < len(app.data)` is not correct because the last `staff_id` in the CSV file does not need to be equal to the length of the data. 