### PR TITLE
fix: Add STAFF_COLUMNS constant and use it to validate column names

### DIFF
--- a/04_db/index.md
+++ b/04_db/index.md
@@ -7,7 +7,7 @@
 -   And use a flag to convert types like dates and times (used later)
 -   [`models_sql.py`](./models_sql.py) implements model part of model-view-controller (MVC)
     -   One function for each question we might ask of our data
-    -   Use SQL directly instead of an object-relational mapper like [SQLAlchemy], [SQLModel][sqlmodel], or [Pony][pony]
+    -   Use SQL directly instead of an object-relational mapper like [SQLAlchemy][SQLAlchemy], [SQLModel][sqlmodel], or [Pony][pony]
     -   ORMs are hard to debug and don't actually provide that much insulation from schema changes
 -   Re-create connection each time model is accessed
     -   Creating it once and attaching to the [FastAPI][fastapi] app fails because of threading
@@ -27,5 +27,6 @@
 [fastapi]: https://fastapi.tiangolo.com/
 [pony]: https://ponyorm.org/
 [pypika]: https://pypika.readthedocs.io/
+[SQLAlchemy]: https://www.sqlalchemy.org/
 [sqlite]: https://www.sqlite.org/
 [sqlmodel]: https://sqlmodel.tiangolo.com/

--- a/04_db/models_pika.py
+++ b/04_db/models_pika.py
@@ -8,6 +8,7 @@ import util
 
 
 ENV_VAR = "DB"
+STAFF_COLUMNS = ["staff_id", "personal", "family"]
 
 
 class ModelException(Exception):
@@ -33,7 +34,7 @@ def connect():
 def all_staff():
     """Get all staff."""
     staff = Table("staff")
-    query = Query.from_(staff).select("staff_id", "personal", "family")
+    query = Query.from_(staff).select(*STAFF_COLUMNS)
     try:
         connection = connect()
         cursor = connection.execute(str(query))
@@ -44,6 +45,9 @@ def all_staff():
 
 def column(name):
     """Get a single column of staff."""
+    if name not in STAFF_COLUMNS:
+        raise ModelException(f"Column '{name}' does not exist")
+
     staff = Table("staff")
     query = Query.from_(staff).select(name)
     try:
@@ -58,7 +62,7 @@ def row(staff_id):
     """Get a single row of staff."""
     staff = Table("staff")
     query = Query.from_(staff) \
-                 .select("staff_id", "personal", "family") \
+                 .select(*STAFF_COLUMNS) \
                  .where(staff.staff_id == staff_id)
     try:
         connection = connect()
@@ -71,3 +75,4 @@ def row(staff_id):
         return result[0]
     except sqlite3.DatabaseError as exc:
         raise ModelException(str(exc))
+


### PR DESCRIPTION
Create a constant list of column names and verify that the column name provided in the URL parameter exists. This fix aims to prevent the Internal Server Error that occurs when attempting to access a non-existent key in this line of `models_pika.py`:`return [r[name] for r in cursor.fetchall()]`