### PR TITLE
feat: Allow specifying port when serving generated HTML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,4 @@ render:
 
 ## serve: serve generated HTML
 serve:
-	@python -m http.server -d docs
+	@python -m http.server -d docs $(PORT)


### PR DESCRIPTION
> I agree that we eventually want to specify the port, but these lessons are just building up experience with tools, so unless the default port is blocked on your machine (or your students' machines) I'd prefer to save the (admittedly small) complexity for later

I understand your concerns but I'd like to explain why I proposed this PR. The `Makefile` file of the root of the project offers a `serve` command to open an http.server and publish the docs/ folder on tcp/8000 by default:
```
@python -m http.server -d docs
````
But in many other folders, we also have other HTTP servers (FastAPI's HTTP server) that use the same tcp/8000 port by default. For instance, `09_browser/server.py` contains an endpoint that returns a random RGB color. If we don't specify a different port for those servers, it's possible to run both of them simultaneously, but not bound to localhost/127.0.0.1 (one of them, Python's HTTP server, will be listening only on http://local_IP:8000, not on localhost/127.0.0.1 like the other). With this pull request, you can specify the port without needing to remember your local IP, making it easier to run both servers simultaneously. Nevertheless, please, feel free to close this PR without merging it. I just wanted to explain why I decided to add it :)