### PR TITLE
fix: avoid http/500 error in simple server login route

### DIFF
--- a/14_crypt/server_simple.py
+++ b/14_crypt/server_simple.py
@@ -41,7 +41,7 @@ def create_app():
             response.set_cookie(COOKIE_NAME, "", expires=0)
             return response
 
-        response.set_cookie(COOKIE_NAME, staff_id, max_age=None)
+        response.set_cookie(COOKIE_NAME, str(staff_id), max_age=None)
         return response
 
     @app.get("/exp/<staff_id>")


### PR DESCRIPTION
Avoid a 500/Internal Server Error in the simple server login route:

```
[2024-08-29 00:11:33,558] ERROR in app: Exception on /login [POST]
Traceback (most recent call last):
...
  File "/opt/wp4ds/14_crypt/server_simple.py", line 44, in login_handler
    response.set_cookie(COOKIE_NAME, staff_id, max_age=None)
  File "/Users/juanan/.pyenv/versions/3.10.8/lib/python3.10/site-packages/werkzeug/sansio/response.py", line 224, in set_cookie
    dump_cookie(
  File "/Users/juanan/.pyenv/versions/3.10.8/lib/python3.10/site-packages/werkzeug/http.py", line 1303, in dump_cookie
    if not _cookie_no_quote_re.fullmatch(value):
TypeError: expected string or bytes-like object
```